### PR TITLE
Use PHP FPM instead of ancient Spawn-FCGI

### DIFF
--- a/files/cgi_pool
+++ b/files/cgi_pool
@@ -1,6 +1,0 @@
--a 127.0.0.1
--p 9000
--C 10
--u www-data
--g www-data
--- /usr/bin/php-cgi

--- a/files/container-run.sh
+++ b/files/container-run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-/etc/init.d/spawn-fcgi start
+/etc/init.d/php5-fpm start
 exec nginx

--- a/handlers/nginx.yml
+++ b/handlers/nginx.yml
@@ -2,5 +2,5 @@
 - name: restart nginx
   service: name=nginx state=restarted
 
-- name: restart spawn_fcgi
-  service: name=spawn-fcgi state=restarted
+- name: restart php5-fpm
+  service: name=php5-fpm state=restarted

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: all
   sudo: yes
+  vars:
+     # php5-fpm
+     max_children: 10
+     start_servers: 2
+     min_spare_servers: 1
+     max_spare_servers: 3
   tasks:
     - include: tasks/nginx.yml
 

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -3,11 +3,10 @@
   apt: name={{ item }} update_cache=yes
   with_items:
     - nginx
-    - php5-cgi
     - php5-curl
-    - spawn-fcgi
+    - php5-fpm
   notify:
-    - restart spawn_fcgi
+    - restart php5-fpm
     - restart nginx
 
 - name: Remove default nginx configuration
@@ -26,18 +25,7 @@
   notify:
     - restart nginx
 
-- name: Create spawn-fcgi directory
-  file: path=/etc/spawn-fcgi state=directory
-
-- name: Configure spawn-fcgi
-  copy: src=files/cgi_pool dest=/etc/spawn-fcgi/phpframework_app
+- name: fpm config
+  action: template src='templates/fpm-pool.conf' dest='/etc/php5/fpm/pool.d/www.conf'
   notify:
-    - restart spawn_fcgi
-
-- name: Set up init script for spawn-fcgi
-  copy: src=files/init-spawn-fcgi.sh dest=/etc/init.d/spawn-fcgi owner=root group=root mode=0755
-  notify:
-    - restart spawn_fcgi
-
-- name: Enable spawn-fcgi service
-  service: name=spawn-fcgi enabled=yes
+    - restart php5-fpm

--- a/templates/fpm-pool.conf
+++ b/templates/fpm-pool.conf
@@ -1,0 +1,239 @@
+; Start a new pool named 'www'.
+; the variable $pool can we used in any directive and will be replaced by the
+; pool name ('www' here)
+[www]
+
+; Per pool prefix
+; It only applies on the following directives:
+; - 'slowlog'
+; - 'listen' (unixsocket)
+; - 'chroot'
+; - 'chdir'
+; - 'php_values'
+; - 'php_admin_values'
+; When not set, the global prefix (or /usr) applies instead.
+; Note: This directive can also be relative to the global prefix.
+; Default Value: none
+;prefix = /path/to/pools/$pool
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses on a
+;                            specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = 127.0.0.1:9000
+
+; Set listen(2) backlog. A value of '-1' means unlimited.
+; Default Value: 128 (-1 on FreeBSD and OpenBSD)
+;listen.backlog = -1
+ 
+; List of ipv4 addresses of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+;listen.allowed_clients = 127.0.0.1
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions. 
+; Default Values: user and group are set as the running user
+;                 mode is set to 0666
+;listen.owner = www-data
+;listen.group = www-data
+;listen.mode = 0666
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+user = www-data
+group = www-data
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives:
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+; Note: This value is mandatory.
+pm = dynamic
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes to be created when pm is set to 'dynamic'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI.
+; Note: Used when pm is set to either 'static' or 'dynamic'
+; Note: This value is mandatory.
+pm.max_children = {{ max_children }} 
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = {{ start_servers }} 
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers =  {{ min_spare_servers }} 
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = {{ max_spare_servers }}  
+ 
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+;pm.max_requests = 500
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. By default, the status page shows the following
+; information:
+;   accepted conn        - the number of request accepted by the pool;
+;   pool                 - the name of the pool;
+;   process manager      - static or dynamic;
+;   idle processes       - the number of idle processes;
+;   active processes     - the number of active processes;
+;   total processes      - the number of idle + active processes.
+;   max children reached - number of times, the process limit has been reached,
+;                          when pm tries to start more children (works only for
+;                          pm 'dynamic')
+; The values of 'idle processes', 'active processes' and 'total processes' are
+; updated each second. The value of 'accepted conn' is updated in real time.
+; Example output:
+;   accepted conn:        12073
+;   pool:                 www
+;   process manager:      static
+;   idle processes:       35
+;   active processes:     65
+;   total processes:      100
+;   max children reached: 1
+; By default the status page output is formatted as text/plain. Passing either
+; 'html' or 'json' as a query string will return the corresponding output
+; syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set 
+;pm.status_path = /status
+ 
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+;ping.path = /ping
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+;ping.response = pong
+ 
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_terminate_timeout = 0
+ 
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+;request_slowlog_timeout = 0
+ 
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+;slowlog = log/$pool.log.slow
+ 
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+;rlimit_files = 1024
+ 
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+;rlimit_core = 0
+ 
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: you can prefix with '$prefix' to chroot to the pool prefix or one
+; of its subdirectories. If the pool prefix is not set, the global prefix
+; will be used instead.
+; Note: chrooting is a great security feature and should be used whenever 
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+;chroot = 
+ 
+; Chdir to this directory at the start.
+; Note: relative path can be used.
+; Default Value: current directory or / when chroot
+chdir = /
+ 
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Note: on highloaded environement, this can cause some delay in the page
+; process time (several ms).
+; Default Value: no
+;catch_workers_output = yes
+ 
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'. 
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Note: path INI options can be relative and will be expanded with the prefix
+; (pool, global or /usr)
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[error_log] = /var/log/fpm-php.www.log
+;php_admin_flag[log_errors] = on
+;php_admin_value[memory_limit] = 32M


### PR DESCRIPTION
Use the default FPM config, except the max_children, which is set to 10
as it was with spawn-fcgi.

@Luzifer PTAL
